### PR TITLE
Fixed Missing C-header for exit

### DIFF
--- a/lua_simplifier.cc
+++ b/lua_simplifier.cc
@@ -27,6 +27,7 @@ SOFTWARE.
 // identical Lua instructions when passed to 'luac -l'.
 
 #include <stdio.h>
+#include <cstdlib>
 #include "util.h"
 #include "lua_simplifier.h"
 


### PR DESCRIPTION
lua_simplifier.cc:47:3: error: use of undeclared identifier 'exit'
  exit(1);