### PR TITLE
Codechange: Introduce variables for the external lua references, for easier customization

### DIFF
--- a/CHECK_LUA.sh
+++ b/CHECK_LUA.sh
@@ -2,6 +2,7 @@
 
 SRC=$1
 CLEAN_ASM="while(<>){s/^\t(\d+)\t\[\d+\]/\t\1/;s/(main|function) <[^\]]+>/function/;s/0x[0-9a-f]+//;print}"
+LUAC=lua/src/luac
 
 # Some shell settings
 set -o pipefail
@@ -17,9 +18,9 @@ function check() {
 echo "Step 1"
 rm -f /tmp/original.asm /tmp/simplified.asm /tmp/original.luac /tmp/simplified.luac
 check
-lua/src/luac -s -l -o /tmp/original.luac $SRC | perl -e "$CLEAN_ASM" > /tmp/original.asm
+$LUAC -s -l -o /tmp/original.luac $SRC | perl -e "$CLEAN_ASM" > /tmp/original.asm
 check
-./lua_simplifier -luac $SRC | lua/src/luac -s -l -o /tmp/simplified.luac - | perl -e "$CLEAN_ASM" > /tmp/simplified.asm
+./lua_simplifier -luac $SRC | $LUAC -s -l -o /tmp/simplified.luac - | perl -e "$CLEAN_ASM" > /tmp/simplified.asm
 check
 diff /tmp/original.asm /tmp/simplified.asm
 check

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
+LUA_INCLUDE_DIR = -Ilua/src
+LUA_LIB = lua/src/liblua.a
 
 APPS=lua_simplifier lua_checker
 
 GENERATED_FILES=lua_lexxer.cc  lua_parser.cc  lua_parser.h lua_checker_parser.cc lua_checker_parser.h
 
-CFLAGS=-Wall -g -Ilua/src -MMD
+CFLAGS=-Wall -g $(LUA_INCLUDE_DIR) -MMD
 
 all: $(APPS)
 
 lua_simplifier: lua_simplifier.o lua_lexxer.o lua_parser.o util.o
-	g++ $(CFLAGS) -o $@ $(OBJS) $^ lua/src/liblua.a
+	g++ $(CFLAGS) -o $@ $(OBJS) $^ $(LUA_LIB)
 
 lua_checker: lua_checker.o lua_lexxer.o lua_checker_parser.o util.o
-	g++ $(CFLAGS) -o $@ $(OBJS) $^ lua/src/liblua.a
+	g++ $(CFLAGS) -o $@ $(OBJS) $^ $(LUA_LIB)
 
 %.o: %.cc
 	g++ -c $(CFLAGS) $<


### PR DESCRIPTION
Wanted to use an installed lua version, so the lua paths were wrong at several places.
Added some variables to make it easier to point to other files instead.

The program doesn't work for CorsixTH though, I guess it has too many custom extensions that confuses the checker.
